### PR TITLE
Added Mod message Receiver for mod interoperation

### DIFF
--- a/hotkey-bar/HotkeysPanel.cs
+++ b/hotkey-bar/HotkeysPanel.cs
@@ -95,7 +95,7 @@ namespace Assets.Scripts.MyMods
         {
             var windowType = DaggerfallUI.Instance.UserInterfaceManager.TopWindow.GetType();
 
-            if (windowType == typeof(DaggerfallInventoryWindow) || windowType == typeof(HotkeysSpellBookWindow) || (windowType?.IsSubclassOf(typeof(DaggerfallInventoryWindow)) ?? false))
+            if (windowType == typeof(DaggerfallInventoryWindow) || windowType == typeof(DaggerfallSpellBookWindow) || (windowType?.IsSubclassOf(typeof(DaggerfallSpellBookWindow)) ?? false || (windowType?.IsSubclassOf(typeof(DaggerfallInventoryWindow)) ?? false)))
             {
                 UpdateIcons();
             }

--- a/hotkey-bar/HotkeysSpellBookWindow.cs
+++ b/hotkey-bar/HotkeysSpellBookWindow.cs
@@ -1,12 +1,5 @@
-using DaggerfallConnect.Arena2;
-using DaggerfallWorkshop.Game;
 using DaggerfallWorkshop.Game.UserInterface;
 using DaggerfallWorkshop.Game.UserInterfaceWindows;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using UnityEngine;
-using static HotkeysMod;
 
 namespace Assets.Scripts.MyMods
 {
@@ -17,28 +10,7 @@ namespace Assets.Scripts.MyMods
         public HotkeysSpellBookWindow(IUserInterfaceManager uiManager, DaggerfallBaseWindow previous = null, bool buyMode = false)
             : base(uiManager, previous, buyMode)
         {
-            instance.OnHotkeyAssigned += HotKeyAssignedHandler;
-        }
 
-        public void HotKeyAssignedHandler(object o, EventArgs e)
-        {
-            var hotkeyEventArgs = (HotkeyEventArgs)e;
-
-            var windowType = DaggerfallUI.Instance.UserInterfaceManager.TopWindow.GetType();
-
-            if (windowType == typeof(HotkeysSpellBookWindow))
-            {
-                var tokens = new List<TextFile.Token>();
-
-                tokens.Add(new TextFile.Token { formatting = TextFile.Formatting.Text, text = $"{spellsListBox.SelectedItem} has been assigned to Hotkey: {hotkeyEventArgs.HotKeyCode.ToString().Last()}" });
-                tokens.Add(new TextFile.Token { formatting = TextFile.Formatting.JustifyCenter });
-
-                DaggerfallMessageBox messageBox = new DaggerfallMessageBox(DaggerfallUI.UIManager, DaggerfallMessageBox.CommonMessageBoxButtons.Nothing, tokens.ToArray(), this);
-                messageBox.ClickAnywhereToClose = true;
-                messageBox.AllowCancel = false;
-                messageBox.ParentPanel.BackgroundColor = Color.clear;
-                DaggerfallUI.UIManager.PushWindow(messageBox);
-            }
         }
 
         #endregion


### PR DESCRIPTION
Two functions:
- RegisterHotkey: takes a keycode, a selection id, and a hotkey type (as Tuple<KeyCode, int, string>) and registers the hotkey
- GetMaxHotkeyBarSize: invokes the callback with the hotkey bar size

Also refactored popups to be triggered from HotkeysMod.AssignHotkey, so that the mod message handler can also show that popup. 

Ensured HotkeysPanel refreshes icon when closing the spellbook, no matter which spellbook class it is (ex: another mod also overrides it).

An example on how this is be used can be found here: https://github.com/KABoissonneault/DFU-UnleveledSpells/blob/hotkeybar-interop/Scripts/UnleveledSpellsSpellbookWindow.cs#L31

With this, I can press 1-9 on my own spellbook class, and the hotkey still registers properly.

Sorry for moving your code around a bit, I just wanted to make sure mods didn't have to duplicate your popups. Feel free to revert some changes I made.